### PR TITLE
feat: sfu now relays chat messages to all other clients

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -21,9 +21,11 @@ const httpsServer = https.createServer(credentials, app);
 app.use(cors());
 const RTC_CONFIG = JSON.parse(process.env.RTC_CONFIG) || null;
 const SIGNAL_SERVER_URL = process.env.SIGNAL_SERVER_URL;
-const SFU_ID = process.env.SFU_ID
+const SFU_ID = process.env.SFU_ID;
 if (!SFU_ID || !RTC_CONFIG || !SIGNAL_SERVER_URL) {
-  throw new Error("A valid .env configuration file needs to be included to run this server. Please refer to the documentation for more details.")
+  throw new Error(
+    'A valid .env configuration file needs to be included to run this server. Please refer to the documentation for more details.'
+  );
 }
 const sfu = new SFU(SIGNAL_SERVER_URL, RTC_CONFIG, SFU_ID);
 sfu.listen();

--- a/src/classes/Client.js
+++ b/src/classes/Client.js
@@ -26,7 +26,7 @@ class Client {
     const { remotePeerId } = data;
     const consumer = this.findConsumerById(remotePeerId);
     if (!consumer) {
-      console.log('error: consumer not found')
+      console.log('error: consumer not found');
       return;
     }
     consumer.handshake(data);
@@ -78,6 +78,10 @@ class Client {
   pruneClient() {
     this.producer.closeConnection();
     this.consumers.forEach((consumer) => consumer.closeConnection());
+  }
+
+  sendChatMessage(data) {
+    this.producer.sendChatMessage(data);
   }
 }
 

--- a/src/classes/Consumer.js
+++ b/src/classes/Consumer.js
@@ -75,7 +75,7 @@ class Consumer {
     console.log(data);
     const { description, candidate } = data;
     if (description) {
-      description.sdp = this.modifyIceAttributes(description.sdp);
+      // description.sdp = this.modifyIceAttributes(description.sdp);
       await this.connection.setRemoteDescription(description);
       this.processQueuedCandidates();
     } else if (candidate) {

--- a/src/classes/Producer.js
+++ b/src/classes/Producer.js
@@ -69,7 +69,7 @@ class Producer {
       }
 
       this.isNegotiating = true;
-      description.sdp = this.modifyIceAttributes(description.sdp);
+      // description.sdp = this.modifyIceAttributes(description.sdp);
       await this.connection.setRemoteDescription(description);
       this.isNegotiating = false;
 
@@ -129,9 +129,21 @@ class Producer {
       negotiated: true,
       id: 100,
     });
-    this.connection.chatChannel.onmessage = (event) => {
-      console.log('Got a chat message from the SFU', event.data);
-    };
+    this.connection.chatChannel.onmessage = this.handleChatMessage.bind(this);
+  }
+
+  handleChatMessage(event) {
+    console.log(event);
+    const data = JSON.parse(event.data);
+    this.eventEmitter.emit('chatMessage', data);
+  }
+
+  sendChatMessage(data) {
+    console.log(
+      `In the other connected Producer (${this.clientId}), gonna send a chat message`
+    );
+    console.log(data);
+    this.connection.chatChannel.send(JSON.stringify(data));
   }
 
   addFeaturesChannel() {

--- a/src/classes/SFU.js
+++ b/src/classes/SFU.js
@@ -22,6 +22,19 @@ class SFU {
       'featuresShared',
       this.handleFeaturesShared.bind(this)
     );
+    this.eventEmitter.on('chatMessage', this.handleChatMessage.bind(this));
+  }
+
+  handleChatMessage(data) {
+    console.log('Got a chat message IN SFU Class');
+    console.log(data);
+    this.clients.forEach((client, clientId) => {
+      if (clientId === data.sender) {
+        return;
+      }
+
+      client.sendChatMessage(data);
+    });
   }
 
   handleFeaturesShared({ id, features, initialConnect }) {
@@ -150,7 +163,7 @@ class SFU {
     });
   }
 
-  addClient(clientId) { 
+  addClient(clientId) {
     this.clients.set(
       clientId,
       new Client(


### PR DESCRIPTION
When a Client sends a message over the chat channel, the SFU will relay that to all clients except the one that sent it. Note: This will break the send message button the Client currently, as the Client isn't sending JSON as the chat message, will post the code below that needs to be change if you wish to use it until that repo is updated